### PR TITLE
Fixed cmake issues of having multiple geometry targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,20 @@ function(find_deps package url)
     if (${package}_FOUND)
         message(STATUS "${PROJECT_NAME} found package ${package}")
     elseif(TARGET ${package})
+        string(LENGTH ${CMAKE_CURRENT_SOURCE_DIR} cur_src_len)
+        string(LENGTH "/lib/${PROJECT_NAME}" proj_len)
+        math(EXPR substr_len "${cur_src_len} - ${proj_len}")
+        string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} 0 ${substr_len} PARENT_DIR)
         if(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
             message(STATUS 
                 "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
             set(${package}_INCLUDE_DIRS
                 ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
+        elseif(EXISTS ${PARENT_DIR}/lib/${package})
+            message(STATUS 
+                "${PROJECT_NAME} found ${package} in ${PARENT_DIR}/lib")
+            set(${package}_INCLUDE_DIRS
+                ${PARENT_DIR}/lib/${package}/include PARENT_SCOPE)
         else()
             message(STATUS 
                 "${PROJECT_NAME} could not find existing ${package} TARGET")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ function(find_deps package url)
 endfunction()
 
 find_deps(geometry https://github.com/superjax/geometry)
-find_deps(gnss_utils https://github.com/mhask94/gnss_utils)
+find_deps(gnss_utils https://github.com/superjax/gnss_utils)
 find_deps(nanoflann_eigen https://github.com/superjax/nanoflann_eigen)
 find_deps(lin_alg_tools https://github.com/superjax/lin_alg_tools)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,57 +1,16 @@
 cmake_minimum_required (VERSION 2.8.11)
 project (multirotor_sim)
 
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(LAPACK REQUIRED)
 
-function(find_deps package url)
-    find_package(${package} QUIET)
-    if (${package}_FOUND)
-        message(STATUS "${PROJECT_NAME} found package ${package}")
-    elseif(TARGET ${package})
-        string(LENGTH ${CMAKE_CURRENT_SOURCE_DIR} cur_src_len)
-        string(LENGTH "/lib/${PROJECT_NAME}" proj_len)
-        math(EXPR substr_len "${cur_src_len} - ${proj_len}")
-        string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} 0 ${substr_len} PARENT_DIR)
-        if(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
-            message(STATUS 
-                "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
-            set(${package}_INCLUDE_DIRS
-                ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
-        elseif(EXISTS ${PARENT_DIR}/lib/${package})
-            message(STATUS 
-                "${PROJECT_NAME} found ${package} in ${PARENT_DIR}/lib")
-            set(${package}_INCLUDE_DIRS
-                ${PARENT_DIR}/lib/${package}/include PARENT_SCOPE)
-        else()
-            message(STATUS 
-                "${PROJECT_NAME} could not find existing ${package} TARGET")
-        endif()
-    elseif(EXISTS ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        message(STATUS 
-            "${PROJECT_NAME} found ${package} in ${PROJECT_NAME}/lib/")
-        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        set(${package}_INCLUDE_DIRS 
-            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
-    else()
-        message(STATUS "${PROJECT_NAME} did not find ${package}")
-        message(STATUS "cloning ${package} into local ${PROJECT_NAME}/lib/")
-        # Clone and create the proper variables
-        file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
-        execute_process(COMMAND 
-            git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        set(${package}_INCLUDE_DIRS 
-            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
-    endif()
-endfunction()
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/findDeps.cmake)
 
 find_deps(geometry https://github.com/superjax/geometry)
-find_deps(gnss_utils https://github.com/superjax/gnss_utils)
+find_deps(gnss_utils https://github.com/mhask94/gnss_utils)
 find_deps(nanoflann_eigen https://github.com/superjax/nanoflann_eigen)
 find_deps(lin_alg_tools https://github.com/superjax/lin_alg_tools)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(LAPACK REQUIRED)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/findDeps.cmake)
 
 find_deps(geometry https://github.com/superjax/geometry)
-find_deps(gnss_utils https://github.com/mhask94/gnss_utils)
+find_deps(gnss_utils https://github.com/superjax/gnss_utils)
 find_deps(nanoflann_eigen https://github.com/superjax/nanoflann_eigen)
 find_deps(lin_alg_tools https://github.com/superjax/lin_alg_tools)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,19 +11,38 @@ find_package(LAPACK REQUIRED)
 function(find_deps package url)
     find_package(${package} QUIET)
     if (${package}_FOUND)
-        message(STATUS found ${package})
+        message(STATUS "${PROJECT_NAME} found package ${package}")
+    elseif(TARGET ${package})
+        if(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
+            message(STATUS 
+                "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
+            set(${package}_INCLUDE_DIRS
+                ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
+        else()
+            message(STATUS 
+                "${PROJECT_NAME} could not find existing ${package} TARGET")
+        endif()
+    elseif(EXISTS ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        message(STATUS 
+            "${PROJECT_NAME} found ${package} in ${PROJECT_NAME}/lib/")
+        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        set(${package}_INCLUDE_DIRS 
+            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
     else()
-        message(STATUS "did not find ${package}, cloning into local lib/ folder")
+        message(STATUS "${PROJECT_NAME} did not find ${package}")
+        message(STATUS "cloning ${package} into local ${PROJECT_NAME}/lib/")
         # Clone and create the proper variables
         file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
-        execute_process(COMMAND git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        execute_process(COMMAND 
+            git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
         add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        set(${package}_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include)
+        set(${package}_INCLUDE_DIRS 
+            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
     endif()
 endfunction()
 
 find_deps(geometry https://github.com/superjax/geometry)
-find_deps(gnss_utils https://github.com/superjax/gnss_utils)
+find_deps(gnss_utils https://github.com/mhask94/gnss_utils)
 find_deps(nanoflann_eigen https://github.com/superjax/nanoflann_eigen)
 find_deps(lin_alg_tools https://github.com/superjax/lin_alg_tools)
 

--- a/cmake/findDeps.cmake
+++ b/cmake/findDeps.cmake
@@ -1,0 +1,28 @@
+function(find_deps package url)
+    find_package(${package} QUIET)
+    if (${package}_FOUND)
+        message(STATUS "${PROJECT_NAME} found package ${package}")
+    elseif(TARGET ${package})
+        if(NOT ${package}_INCLUDE_DIRS STREQUAL "")
+            message(STATUS "${PROJECT_NAME} found ${package}_INCLUDE_DIRS")
+        elseif(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
+            message(STATUS 
+                "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
+            set(${package}_INCLUDE_DIRS
+                ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
+        else()
+            message(SEND_ERROR "${PROJECT_NAME} could't find ${package} TARGET")
+        endif()
+    else()
+        if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+            message(STATUS "${PROJECT_NAME} did not find ${package}")
+            file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
+            execute_process(COMMAND 
+                git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        endif()
+        message(STATUS "${PROJECT_NAME} is using local lib/${package}")
+        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        set(${package}_INCLUDE_DIRS 
+            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
+    endif()
+endfunction()


### PR DESCRIPTION
I modified the dependency function so that it checks to see if the package is already a target. If it is, cmake will look for lib/${package} in the directory with the root CMakeLists.txt. Also, the function now checks to see if the package has already been cloned before trying to clone it.